### PR TITLE
feat: add encryptedPrivateKey field to dataApp schema

### DIFF
--- a/schemaTypes/dataApp.ts
+++ b/schemaTypes/dataApp.ts
@@ -176,6 +176,15 @@ export const dataApp = defineType({
       description: 'ID of the grantee for data portability operations',
       validation: (Rule) => Rule.integer().min(0),
     }),
+
+    defineField({
+      name: 'encryptedPrivateKey',
+      type: 'text',
+      title: 'Encrypted Private Key',
+      description:
+        'The secure identity key for this app. When users grant this app permission to access their data, they authorize this specific key. The app uses it to connect to users\' personal servers and retrieve their data. For security, this key is encrypted with the Vana App\'s public key.',
+      validation: (Rule) => Rule.required(),
+    }),
   ],
 
   preview: {


### PR DESCRIPTION
## Summary
- Added a required `encryptedPrivateKey` field to the dataApp schema
- This field stores the secure identity key for each data app, encrypted with the Vana App's public key
- The key is used for user data permission authorization and authentication with personal servers

## Implementation Details
- Field type: `text` (to store the encrypted key string)
- Validation: Required field
- Location: Added after the `grantee` field for logical grouping of permission-related fields
- User-friendly description explaining the field's purpose and security

## Note on Required Field
Making this field required means:
- Existing data apps will continue to work as-is
- When editing any existing data app in Sanity Studio, the encrypted private key must be populated before saving
- This ensures all actively maintained apps get updated with their secure identity keys

## Test plan
- [ ] Deploy to staging and verify the field appears in Sanity Studio
- [ ] Test creating a new data app with the encrypted private key field
- [ ] Test editing an existing data app and confirm it requires the field to be populated

🤖 Generated with [Claude Code](https://claude.ai/code)