### PR TITLE
feat: add financial and valuation fields to DataDAO and DataSource sc…

### DIFF
--- a/schemaTypes/dataDAO.ts
+++ b/schemaTypes/dataDAO.ts
@@ -492,6 +492,16 @@ export const dataDAO = defineType({
       fieldset: 'tokenomics',
     }),
 
+    defineField({
+      name: 'fdvDiscountPct',
+      type: 'number',
+      title: 'FDV Discount Percentage',
+      description: 'Percentage reduction applied to FDV',
+      initialValue: 0,
+      validation: (Rule) => Rule.min(0).max(100),
+      fieldset: 'tokenomics',
+    }),
+
     // Data Access
     defineField({
       name: 'operationsAllowed',

--- a/schemaTypes/dataSource.ts
+++ b/schemaTypes/dataSource.ts
@@ -56,6 +56,24 @@ export const dataSource = defineType({
       ],
       validation: (Rule) => Rule.required().min(1),
     }),
+
+    defineField({
+      name: 'valuePerDataPointUSD',
+      type: 'number',
+      title: 'Value in USD per Data Point',
+      description: 'Estimated value in USD for each data point within this Datasource',
+      initialValue: 0.00,
+      validation: (Rule) => Rule.min(0),
+    }),
+
+    defineField({
+      name: 'sectorMultiplier',
+      type: 'number',
+      title: 'Sector Multiplier',
+      description: 'Multiplier factor for this data source sector',
+      initialValue: 1,
+      validation: (Rule) => Rule.min(0),
+    }),
   ],
 
   preview: {


### PR DESCRIPTION

Added three new admin-editable fields for financial calculations:
- DataDAO: fdvDiscountPct - percentage reduction applied to FDV (0-100%)
- DataSource: valuePerDataPointUSD - estimated USD value per data point
- DataSource: sectorMultiplier - multiplier factor for sector valuation

🤖 Generated with [Claude Code](https://claude.ai/code)