### PR TITLE
feat(DX-13): Add file upload schema for synthetic data samples

### DIFF
--- a/schemaTypes/schema.ts
+++ b/schemaTypes/schema.ts
@@ -39,7 +39,8 @@ export const schema = defineType({
       name: 'sampleData',
       type: 'file',
       title: 'Data Sample (Refined)',
-      description: 'Sample sqlite/libsql file showing 100 rows of refined dummy data',
+      description:
+        'A sample data file (e.g., JSON, SQLite) representing the structure of this schema.',
       options: {
         accept: '.db,.sqlite,.libsql,.json',
       },

--- a/schemaTypes/schema.ts
+++ b/schemaTypes/schema.ts
@@ -34,6 +34,16 @@ export const schema = defineType({
           'Must be a valid UUID format'
         ),
     }),
+
+    defineField({
+      name: 'sampleData',
+      type: 'file',
+      title: 'Data Sample (Refined)',
+      description: 'Sample sqlite/libsql file showing 100 rows of refined dummy data',
+      options: {
+        accept: '.db,.sqlite,.libsql,.json',
+      },
+    }),
   ],
 
   preview: {

--- a/schemaTypes/schema.ts
+++ b/schemaTypes/schema.ts
@@ -38,7 +38,7 @@ export const schema = defineType({
     defineField({
       name: 'sampleData',
       type: 'file',
-      title: 'Data Sample (Refined)',
+      title: 'Data Sample',
       description:
         'A sample data file (e.g., JSON, SQLite) representing the structure of this schema.',
       options: {


### PR DESCRIPTION
This PR updates the Sanity `schema` document type to support uploading synthetic data samples as files.

- Adds a new `sampleData` field of type `file`.
- Configures the field to accept `.db`, `.sqlite`, `.libsql`, and `.json` file types.

This change is required for the synthetic data generator feature in the main application to correctly fetch and display sample data.

<img width="667" height="392" alt="image" src="https://github.com/user-attachments/assets/5b274b0e-eac5-4e86-a79b-a17f9bdf679f" />
