### PR TITLE
fix: make refiner temporarily editable and do not override from subgraph with latest

### DIFF
--- a/schemaTypes/dataDAO.ts
+++ b/schemaTypes/dataDAO.ts
@@ -369,7 +369,7 @@ export const dataDAO = defineType({
       type: 'number',
       title: 'Refiner ID',
       description: 'ID of the latest refiner (auto-synced from subgraph)',
-      readOnly: true,
+      // TODO: ROLLBACK-BNU: readOnly: true,
       fieldset: 'dataManagement',
     }),
 
@@ -378,7 +378,7 @@ export const dataDAO = defineType({
       type: 'url',
       title: 'Data Schema (Refined)',
       description: 'URL to IPFS or documentation of refined data schema',
-      readOnly: true,
+      // TODO: ROLLBACK-BNU: readOnly: true,
       fieldset: 'dataManagement',
     }),
 

--- a/scripts/update-datadaos.ts
+++ b/scripts/update-datadaos.ts
@@ -368,12 +368,12 @@ async function mapSubgraphAuthorityFields(
   mapped.filesCount = subgraphData.totalFileContributions
 
   // Data schema refined URL - always from subgraph (latest refiner)
-  if (subgraphData.latestSchemaDefinitionUrl) {
+  if (!existingData?.dataSchemaRefined || existingData?.dataSchemaRefined === '' && subgraphData.latestSchemaDefinitionUrl) {
     mapped.dataSchemaRefined = subgraphData.latestSchemaDefinitionUrl
   }
-
+  // TODO: ROLLBACK-BNU: 
   // Refiner ID - always from subgraph (latest refiner)
-  if (subgraphData.latestRefinerId) {
+  if (!existingData?.refinerId || existingData?.refinerId === 0 && subgraphData.latestRefinerId) {
     mapped.refinerId = subgraphData.latestRefinerId
   }
 


### PR DESCRIPTION
Motivation: Displaying additional valid DLPs on mainnet for outreach